### PR TITLE
use uintptr_t instead of intptr_t to avoid warming C4018 in Virsual Studio.

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -498,7 +498,7 @@ static void XorWithIv(uint8_t* buf)
 
 void AES128_CBC_encrypt_buffer(uint8_t* output, uint8_t* input, uint32_t length, const uint8_t* key, const uint8_t* iv)
 {
-  intptr_t i;
+  uintptr_t i;
   uint8_t remainders = length % KEYLEN; /* Remaining bytes in the last non-full block */
 
   BlockCopy(output, input);
@@ -538,7 +538,7 @@ void AES128_CBC_encrypt_buffer(uint8_t* output, uint8_t* input, uint32_t length,
 
 void AES128_CBC_decrypt_buffer(uint8_t* output, uint8_t* input, uint32_t length, const uint8_t* key, const uint8_t* iv)
 {
-  intptr_t i;
+  uintptr_t i;
   uint8_t remainders = length % KEYLEN; /* Remaining bytes in the last non-full block */
   
   BlockCopy(output, input);


### PR DESCRIPTION
use uintptr_t instead of intptr_t to avoid warming C4018 in Virsual Studio.

warming C4018: 'expression' : signed/unsigned mismatch
refer: https://msdn.microsoft.com/library/y92ktdf2.aspx