### PR TITLE
Update aes.c

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -299,24 +299,26 @@ static void MixColumns(void)
 }
 
 // Multiply is used to multiply numbers in the field GF(2^8)
-#if MULTIPLY_AS_A_FUNCTION
-static uint8_t Multiply(uint8_t x, uint8_t y)
-{
-  return (((y & 1) * x) ^
-       ((y>>1 & 1) * xtime(x)) ^
-       ((y>>2 & 1) * xtime(xtime(x))) ^
-       ((y>>3 & 1) * xtime(xtime(xtime(x)))) ^
-       ((y>>4 & 1) * xtime(xtime(xtime(xtime(x))))));
+static uint8_t Multiply(uint8_t x, uint8_t y){
+  uint8_t answer;
+  if (y == 1) {
+      answer = x;
+      return answer;
+  } else if (y%2 > 0){
+      y -= 1;
+      answer = RecursiveMultiply(x, y);
+      answer ^= x;
+      return answer;
+  } else if (y >= 2){
+      y /= 2;
+      answer = RecursiveMultiply(x, y);
+      uint8_t ffcheck;
+      ffcheck = (unsigned char)((signed char)answer >> 7);
+      answer = answer << 1;
+      answer ^= 0x1B & ffcheck;
+      return answer;
   }
-#else
-#define Multiply(x, y)                                \
-      (  ((y & 1) * x) ^                              \
-      ((y>>1 & 1) * xtime(x)) ^                       \
-      ((y>>2 & 1) * xtime(xtime(x))) ^                \
-      ((y>>3 & 1) * xtime(xtime(xtime(x)))) ^         \
-      ((y>>4 & 1) * xtime(xtime(xtime(xtime(x))))))   \
-
-#endif
+}
 
 // MixColumns function mixes the columns of the state matrix.
 // The method used to multiply may be difficult to understand for the inexperienced.


### PR DESCRIPTION
I noticed that the inverse mix column function was very complex and wanted to simplify it while tailoring the new function towards the constraints of the project, which is to keep it as condensed as possible.  The benefits of the new Multiply function I have suggested are that it is significantly easier for a user to understand how the finite field multiplication works, it eliminates the need for the xtime() function, and that it operates under close to identical speeds as the original Multiply function.

From my observation, the Inverse Mix Columns function is the most complex function in AES and is not particularly well documented online.  A simpler function may be beneficial towards those who may want to contribute toward Tiny-AES but may
not be all too familiar with the operations.